### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+# E501: line too long
+extend-ignore = E501
+max-line-length = 88
+count = True
+statistics = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+    - id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+    - id: flake8
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.4
+    hooks:
+    - id: pyupgrade

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 Personal Solutions to [Advent of Code](https://adventofcode.com/) puzzles
 
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/matthewfeickert/Advent-of-Code/master.svg)](https://results.pre-commit.ci/latest/github/matthewfeickert/Advent-of-Code/master)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy~=1.17
 black
+pre-commit


### PR DESCRIPTION
Add pre-commit hooks and badge to README

[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/matthewfeickert/Advent-of-Code/master.svg)](https://results.pre-commit.ci/latest/github/matthewfeickert/Advent-of-Code/master)

```
* Add pre-commit hooks
   - black, flake8, pyupgrade
* Add flake8 config file  
* Add pre-commit CI badge to README
```