### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,16 +4,16 @@ ci:
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.11b1
     hooks:
     - id: black
 
 -   repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
     - id: flake8
 
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.29.1
     hooks:
     - id: pyupgrade


### PR DESCRIPTION
updates:
 - github.com/psf/black: 21.9b0 →  21.11b1
 - github.com/PyCQA/flake8: 3.9.2 →  4.0.1
 - github.com/asottile/pyupgrade: v2.29.0 → v2.29.1